### PR TITLE
COMP: fix leak

### DIFF
--- a/MRML/vtkIGTLToMRMLImageMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLImageMetaList.cxx
@@ -60,7 +60,7 @@ vtkMRMLNode* vtkIGTLToMRMLImageMetaList::CreateNewNode(vtkMRMLScene* scene, cons
   imetaNode->SetDescription("Received by OpenIGTLink");
 
   scene->AddNode(imetaNode);
-
+  imetaNode->Delete();
   return imetaNode;
 }
 


### PR DESCRIPTION
The ImageMetaListNode has an extra reference right now, so leaks when Slicer exits.
