### PR TITLE
Fix TDATA segfault

### DIFF
--- a/MRML/vtkMRMLIGTLTrackingDataBundleNode.cxx
+++ b/MRML/vtkMRMLIGTLTrackingDataBundleNode.cxx
@@ -255,6 +255,7 @@ void vtkMRMLIGTLTrackingDataBundleNode::UpdateTransformNode(const char* name, ig
     if (this->GetScene())
       {
       this->GetScene()->AddNode(node);
+      node->Delete();
       }
     TrackingDataInfo info;
     info.type = type;
@@ -278,7 +279,6 @@ void vtkMRMLIGTLTrackingDataBundleNode::UpdateTransformNode(const char* name, ig
     }
   mat->Modified();
   //node->Modified();
-  node->Delete();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Node is deleted multiple times, causing segfault in vtkMRMLScene::
GetNodesByClass

See: https://github.com/SlicerIGT/OpenIGTLinkRemote/issues/18

@tokjun please integrate as soon as possible, this is a blocking issue.
