### PR TITLE
Add 'persistent' option to ConnectorNode state

### DIFF
--- a/GUI/qSlicerIGTLConnectorPropertyWidget.cxx
+++ b/GUI/qSlicerIGTLConnectorPropertyWidget.cxx
@@ -41,6 +41,8 @@ void qSlicerIGTLConnectorPropertyWidgetPrivate::init()
                    q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorStateCheckBox, SIGNAL(toggled(bool)),
                    q, SLOT(startCurrentIGTLConnector(bool)));
+  QObject::connect(this->PersistentStateCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorHostNameEdit, SIGNAL(editingFinished()),
                    q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorPortEdit, SIGNAL(editingFinished()),
@@ -171,6 +173,7 @@ void qSlicerIGTLConnectorPropertyWidget::onMRMLNodeModified()
     setPortEnabled(d, false);
     }
   d->ConnectorStateCheckBox->setChecked(!deactivated);
+  d->PersistentStateCheckBox->setChecked(d->IGTLConnectorNode->GetPersistent() == vtkMRMLIGTLConnectorNode::PERSISTENT_ON);
 }
 
 //------------------------------------------------------------------------------
@@ -199,6 +202,9 @@ void qSlicerIGTLConnectorPropertyWidget::updateIGTLConnectorNode()
   d->IGTLConnectorNode->SetType(d->ConnectorTypeButtonGroup.checkedId());
   d->IGTLConnectorNode->SetServerHostname(d->ConnectorHostNameEdit->text().toStdString());
   d->IGTLConnectorNode->SetServerPort(d->ConnectorPortEdit->text().toInt());
+  d->IGTLConnectorNode->SetPersistent(d->PersistentStateCheckBox->isChecked() ?
+										vtkMRMLIGTLConnectorNode::PERSISTENT_ON :
+										vtkMRMLIGTLConnectorNode::PERSISTENT_OFF);
 
   d->IGTLConnectorNode->DisableModifiedEventOff();
   d->IGTLConnectorNode->InvokePendingModifiedEvent();

--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -68,6 +68,7 @@ vtkMRMLIGTLConnectorNode::vtkMRMLIGTLConnectorNode()
 
   this->Type   = TYPE_NOT_DEFINED;
   this->State  = STATE_OFF;
+  this->Persistent = PERSISTENT_OFF;
 
   this->Thread = vtkMultiThreader::New();
   this->ServerStopFlag = false;
@@ -184,6 +185,7 @@ void vtkMRMLIGTLConnectorNode::WriteXML(ostream& of, int nIndent)
     }
 
   of << " serverPort=\"" << this->ServerPort << "\" ";
+  of << " persistent=\"" << this->Persistent << "\" ";
   of << " state=\"" << this->State <<"\""; 
   of << " restrictDeviceName=\"" << this->RestrictDeviceName << "\" ";
 
@@ -203,6 +205,7 @@ void vtkMRMLIGTLConnectorNode::ReadXMLAttributes(const char** atts)
   int type = -1;
   int restrictDeviceName = 0;
   int state = vtkMRMLIGTLConnectorNode::STATE_OFF;
+  int persistent = vtkMRMLIGTLConnectorNode::PERSISTENT_OFF;
 
   while (*atts != NULL)
     {
@@ -240,13 +243,19 @@ void vtkMRMLIGTLConnectorNode::ReadXMLAttributes(const char** atts)
       ss << attValue;
       ss >> restrictDeviceName;;
       }
+	if (!strcmp(attName, "persistent"))
+	  {
+	  std::stringstream ss;
+	  ss << attValue;
+	  ss >> persistent;
+	  }
     if (!strcmp(attName, "state"))
       {
       std::stringstream ss;
       ss << attValue;
       ss >> state;
       }
-    }
+	}
 
   switch(type)
     {
@@ -262,11 +271,16 @@ void vtkMRMLIGTLConnectorNode::ReadXMLAttributes(const char** atts)
       // do nothing
       break;
     }
-  if (state!=vtkMRMLIGTLConnectorNode::STATE_OFF)
+  if (persistent == vtkMRMLIGTLConnectorNode::PERSISTENT_ON)
+    {
+	this->SetPersistent(vtkMRMLIGTLConnectorNode::PERSISTENT_ON);
+	this->Modified();
+    }
+  if (persistent == vtkMRMLIGTLConnectorNode::PERSISTENT_ON
+	  && state!=vtkMRMLIGTLConnectorNode::STATE_OFF)
     {
     this->Start();
     }
-
 }
 
 
@@ -298,7 +312,8 @@ void vtkMRMLIGTLConnectorNode::Copy(vtkMRMLNode *anode)
       this->SetType(TYPE_NOT_DEFINED);
       break;
     }
-
+  this->State = node->GetState();
+  this->SetPersistent(node->GetPersistent());
 }
 
 

--- a/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/MRML/vtkMRMLIGTLConnectorNode.h
@@ -86,6 +86,11 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
     IO_OUTGOING   = 0x02,
   };
 
+  enum {
+	PERSISTENT_OFF,
+	PERSISTENT_ON,
+  };
+
   typedef struct {
     std::string   name;
     std::string   type;
@@ -170,6 +175,11 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   vtkGetMacro( State, int );
   vtkSetMacro( RestrictDeviceName, int );
   vtkGetMacro( RestrictDeviceName, int );
+
+  // Controls if active connection will be resumed when
+  // scene is loaded (cf: PERSISTENT_ON/_OFF)
+  vtkSetMacro( Persistent, int );
+  vtkGetMacro( Persistent, int );
 
   const char* GetServerHostname();
   void SetServerHostname(std::string str);
@@ -344,6 +354,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   std::string Name;
   int Type;
   int State;
+  int Persistent;
 
   //----------------------------------------------------------------
   // Thread and Socket

--- a/Resources/UI/qSlicerIGTLConnectorPropertyWidget.ui
+++ b/Resources/UI/qSlicerIGTLConnectorPropertyWidget.ui
@@ -68,6 +68,31 @@
         </item>
        </layout>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="ConnectorStateLabel">
+        <property name="text">
+         <string>Status:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="ConnectorStateCheckBox">
+          <property name="text">
+           <string>Active</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="PersistentStateCheckBox">
+          <property name="text">
+           <string>Persistent</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="ConnectorHostnameLabel">
         <property name="text">
@@ -133,20 +158,6 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="ConnectorStateLabel">
-        <property name="text">
-         <string>Status:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="ConnectorStateCheckBox">
-        <property name="text">
-         <string>Active</string>
-        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
This option represents whether or not a connection should
be persistent across scene saves.

if `persistent == ::PERSISTENT_ON` then the node connects
based on the `::state` setting.

if `persistent == ::PERSISTENT_OFF` then the node does not
reconnect when the scene is loaded.
