### PR TITLE
ENH: enabling color image support

### DIFF
--- a/MRML/vtkIGTLToMRMLBase.h
+++ b/MRML/vtkIGTLToMRMLBase.h
@@ -73,7 +73,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLBase : public vtk
   // GetNodeEvents() returns a list of events, which an IGTLConnector should react to.
   // The first element should be an event to export data, although multiple events can be defined.
   virtual vtkIntArray* GetNodeEvents()    { return NULL; };
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* vtkNotUsed(scene), const char* vtkNotUsed(name))
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* vtkNotUsed(scene), igtl::MessageBase::Pointer vtkNotUsed(name))
     { return NULL; };
 
   // for TYPE_MULTI_IGTL_NAMES

--- a/MRML/vtkIGTLToMRMLImage.h
+++ b/MRML/vtkIGTLToMRMLImage.h
@@ -42,7 +42,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImage : public vt
   virtual const char*  GetIGTLName() { return "IMAGE"; };
   virtual const char*  GetMRMLName() { return "Volume"; };
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingImageMessage);
 
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
   virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);

--- a/MRML/vtkIGTLToMRMLLabelMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLLabelMetaList.cxx
@@ -49,8 +49,10 @@ void vtkIGTLToMRMLLabelMetaList::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLNode* vtkIGTLToMRMLLabelMetaList::CreateNewNode(vtkMRMLScene* scene, const char* name)
+vtkMRMLNode* vtkIGTLToMRMLLabelMetaList::CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingLabelMetaListMessage)
 {
+  const char* name = incomingLabelMetaListMessage->GetDeviceName();
+
   vtkMRMLLabelMetaListNode *imetaNode = vtkMRMLLabelMetaListNode::New();
   imetaNode->SetName(name);
   imetaNode->SetDescription("Received by OpenIGTLink");

--- a/MRML/vtkIGTLToMRMLLabelMetaList.h
+++ b/MRML/vtkIGTLToMRMLLabelMetaList.h
@@ -37,7 +37,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLLabelMetaList : p
   virtual const char*  GetMRMLName() { return "LabelMetaList"; };
 
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingLabelMetaListMessage);
 
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
   virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);

--- a/MRML/vtkIGTLToMRMLLinearTransform.cxx
+++ b/MRML/vtkIGTLToMRMLLinearTransform.cxx
@@ -63,8 +63,10 @@ void vtkIGTLToMRMLLinearTransform::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLNode* vtkIGTLToMRMLLinearTransform::CreateNewNode(vtkMRMLScene* scene, const char* name)
+vtkMRMLNode* vtkIGTLToMRMLLinearTransform::CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingLinearTransformMessage)
 {
+  const char* name = incomingLinearTransformMessage->GetDeviceName();
+
   vtkMRMLLinearTransformNode* transformNode;
 
   transformNode = vtkMRMLLinearTransformNode::New();

--- a/MRML/vtkIGTLToMRMLLinearTransform.h
+++ b/MRML/vtkIGTLToMRMLLinearTransform.h
@@ -43,7 +43,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLLinearTransform :
   virtual const char*  GetIGTLName() { return "TRANSFORM"; };
   virtual const char*  GetMRMLName() { return "LinearTransform"; };
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingLinearTransformMessage);
 
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
   virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);

--- a/MRML/vtkIGTLToMRMLPointMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLPointMetaList.cxx
@@ -45,8 +45,10 @@ void vtkIGTLToMRMLPointMetaList::PrintSelf(ostream& os, vtkIndent indent)
 
 
 //---------------------------------------------------------------------------
-vtkMRMLNode* vtkIGTLToMRMLPointMetaList::CreateNewNode(vtkMRMLScene* scene, const char* name)
+vtkMRMLNode* vtkIGTLToMRMLPointMetaList::CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingPointMetaListMessage)
 {
+  const char* name = incomingPointMetaListMessage->GetDeviceName();
+
   vtkMRMLPointMetaListNode *node = vtkMRMLPointMetaListNode::New();
   node->SetName(name);
   node->SetDescription("Received by OpenIGTLink");

--- a/MRML/vtkIGTLToMRMLPointMetaList.h
+++ b/MRML/vtkIGTLToMRMLPointMetaList.h
@@ -35,7 +35,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPointMetaList : p
   virtual const char*  GetMRMLName() { return "PointMetaList"; };
 
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingPointMetaListMessage);
 
   //BTX
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);

--- a/MRML/vtkIGTLToMRMLPosition.cxx
+++ b/MRML/vtkIGTLToMRMLPosition.cxx
@@ -53,8 +53,10 @@ void vtkIGTLToMRMLPosition::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLNode* vtkIGTLToMRMLPosition::CreateNewNode(vtkMRMLScene* scene, const char* name)
+vtkMRMLNode* vtkIGTLToMRMLPosition::CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingPositionMessage)
 {
+  const char* name = incomingPositionMessage->GetDeviceName();
+
   vtkMRMLLinearTransformNode* transformNode;
 
   transformNode = vtkMRMLLinearTransformNode::New();

--- a/MRML/vtkIGTLToMRMLPosition.h
+++ b/MRML/vtkIGTLToMRMLPosition.h
@@ -40,7 +40,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPosition : public
   virtual const char*  GetIGTLName() { return "POSITION"; };
   virtual const char*  GetMRMLName() { return "LinearTransform"; };
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingPositionMessage);
 
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
   virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);

--- a/MRML/vtkIGTLToMRMLTrackingData.cxx
+++ b/MRML/vtkIGTLToMRMLTrackingData.cxx
@@ -56,8 +56,9 @@ void vtkIGTLToMRMLTrackingData::PrintSelf(ostream& os, vtkIndent indent)
 
 
 //---------------------------------------------------------------------------
-vtkMRMLNode* vtkIGTLToMRMLTrackingData::CreateNewNode(vtkMRMLScene* scene, const char* name)
+vtkMRMLNode* vtkIGTLToMRMLTrackingData::CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingTransformMessage)
 {
+  const char* name = incomingTransformMessage->GetDeviceName();
 
   vtkMRMLIGTLTrackingDataBundleNode *node = vtkMRMLIGTLTrackingDataBundleNode::New();
   node->SetName(name);

--- a/MRML/vtkIGTLToMRMLTrackingData.h
+++ b/MRML/vtkIGTLToMRMLTrackingData.h
@@ -43,7 +43,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLTrackingData : pu
   virtual const char*  GetMRMLName() { return "IGTLTrackingDataSplitter"; };
 
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, igtl::MessageBase::Pointer incomingTransformMessage);
 
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
   virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);


### PR DESCRIPTION
Number of components now set from image message.
Display node color table now set depending on number of components.

I'm not sure if there's a clean way of downcasting an igtl::MessageBase into a igtl::ImageMessage so for now I operate on the inner pointer. If anything fails it reverts to the original greyscale image.
