### PR TITLE
ENH: cleaning up build warning and using polymorphism to clean up the calling code

### DIFF
--- a/MRML/vtkIGTLToMRMLBase.h
+++ b/MRML/vtkIGTLToMRMLBase.h
@@ -78,7 +78,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLBase : public vtk
   virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* vtkNotUsed(scene), const char* vtkNotUsed(name))
   { return NULL; };
   // This call enables the created node to query the message to determine any necessary properties
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer vtkNotUsed(message))
+  virtual vtkMRMLNode* CreateNewNodeWithMessage(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer vtkNotUsed(message))
   { return this->CreateNewNode(scene, name); };
 
   // for TYPE_MULTI_IGTL_NAMES

--- a/MRML/vtkIGTLToMRMLImage.cxx
+++ b/MRML/vtkIGTLToMRMLImage.cxx
@@ -61,7 +61,7 @@ void vtkIGTLToMRMLImage::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLNode* vtkIGTLToMRMLImage::CreateNewNode(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer incomingImageMessage)
+vtkMRMLNode* vtkIGTLToMRMLImage::CreateNewNodeWithMessage(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer incomingImageMessage)
 {
   vtkMRMLScalarVolumeDisplayNode *displayNode(NULL);
   int numberOfComponents(1);

--- a/MRML/vtkIGTLToMRMLImage.h
+++ b/MRML/vtkIGTLToMRMLImage.h
@@ -42,7 +42,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImage : public vt
   virtual const char*  GetIGTLName() { return "IMAGE"; };
   virtual const char*  GetMRMLName() { return "Volume"; };
   virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer incomingImageMessage);
+  virtual vtkMRMLNode* CreateNewNodeWithMessage(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer incomingImageMessage);
 
   virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
   virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);

--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -1031,7 +1031,7 @@ void vtkMRMLIGTLConnectorNode::ImportDataFromCircularBuffer()
         if (nCol == 0)
           {
           // Call the advanced creation call first to see if the requested converter needs the message itself
-          vtkMRMLNode* node = converter->CreateNewNode(this->GetScene(), buffer->GetDeviceName(), buffer);
+          vtkMRMLNode* node = converter->CreateNewNodeWithMessage(this->GetScene(), buffer->GetDeviceName(), buffer);
           NodeInfoType* nodeInfo = RegisterIncomingMRMLNode(node);
           node->DisableModifiedEventOn();
           converter->IGTLToMRML(buffer, node);


### PR DESCRIPTION
3 parameter version of CreateNewNode in base class calls 2 parameter version. If the 3 param isn't overrided in the derived classes, the 2 param version will be called (as per existing structure).
