### PR TITLE
ENH: Support VTK6.

### DIFF
--- a/Logic/vtkSlicerOpenIGTLinkIFLogic.cxx
+++ b/Logic/vtkSlicerOpenIGTLinkIFLogic.cxx
@@ -35,7 +35,6 @@
 #include <vtkTransform.h>
 
 //---------------------------------------------------------------------------
-vtkCxxRevisionMacro(vtkSlicerOpenIGTLinkIFLogic, "$Revision: 1.9.12.1 $");
 vtkStandardNewMacro(vtkSlicerOpenIGTLinkIFLogic);
 
 //---------------------------------------------------------------------------

--- a/Logic/vtkSlicerOpenIGTLinkIFLogic.h
+++ b/Logic/vtkSlicerOpenIGTLinkIFLogic.h
@@ -73,7 +73,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_LOGIC_EXPORT vtkSlicerOpenIGTLinkIFLogic :
  public:
 
   static vtkSlicerOpenIGTLinkIFLogic *New();
-  vtkTypeRevisionMacro(vtkSlicerOpenIGTLinkIFLogic, vtkSlicerModuleLogic);
+  vtkTypeMacro(vtkSlicerOpenIGTLinkIFLogic, vtkSlicerModuleLogic);
   void PrintSelf(ostream&, vtkIndent);
 
   /// The selected transform node is observed for TransformModified events and the transform

--- a/MRML/vtkIGTLCircularBuffer.cxx
+++ b/MRML/vtkIGTLCircularBuffer.cxx
@@ -28,7 +28,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLCircularBuffer);
-vtkCxxRevisionMacro(vtkIGTLCircularBuffer, "$Revision: 10236 $");
 
 //---------------------------------------------------------------------------
 vtkIGTLCircularBuffer::vtkIGTLCircularBuffer()

--- a/MRML/vtkIGTLCircularBuffer.h
+++ b/MRML/vtkIGTLCircularBuffer.h
@@ -36,7 +36,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLCircularBuffer : public
  public:
 
   static vtkIGTLCircularBuffer *New();
-  vtkTypeRevisionMacro(vtkIGTLCircularBuffer,vtkObject);
+  vtkTypeMacro(vtkIGTLCircularBuffer,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLBase.cxx
+++ b/MRML/vtkIGTLToMRMLBase.cxx
@@ -31,7 +31,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLBase);
-vtkCxxRevisionMacro(vtkIGTLToMRMLBase, "$Revision: 10576 $");
 
 //---------------------------------------------------------------------------
 class vtkIGTLToMRMLBasePrivate

--- a/MRML/vtkIGTLToMRMLBase.h
+++ b/MRML/vtkIGTLToMRMLBase.h
@@ -53,7 +53,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLBase : public vtk
  public:
 
   static vtkIGTLToMRMLBase *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLBase,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLBase,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLImage.cxx
+++ b/MRML/vtkIGTLToMRMLImage.cxx
@@ -42,8 +42,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLImage);
-vtkCxxRevisionMacro(vtkIGTLToMRMLImage, "$Revision: 15621 $");
-
 //---------------------------------------------------------------------------
 vtkIGTLToMRMLImage::vtkIGTLToMRMLImage()
 {
@@ -91,15 +89,21 @@ vtkMRMLNode* vtkIGTLToMRMLImage::CreateNewNodeWithMessage(vtkMRMLScene* scene, c
   image->SetSpacing(1.0, 1.0, 1.0);
   //image->SetOrigin( fov/2, -fov/2, -0.0 );
   image->SetOrigin(0.0, 0.0, 0.0);
+#if (VTK_MAJOR_VERSION <= 5)
   image->SetNumberOfScalarComponents(numberOfComponents);
   image->SetScalarTypeToShort();
   image->AllocateScalars();
+#else
+  image->AllocateScalars(VTK_SHORT, numberOfComponents);
+#endif
 
   short* dest = (short*) image->GetScalarPointer();
   if (dest)
     {
     memset(dest, 0x00, 256*256*sizeof(short));
+#if (VTK_MAJOR_VERSION <= 5)
     image->Update();
+#endif
     }
 
   scalarNode->SetAndObserveImageData(image);
@@ -116,11 +120,15 @@ vtkMRMLNode* vtkIGTLToMRMLImage::CreateNewNodeWithMessage(vtkMRMLScene* scene, c
     scalarNode->SetName(name);
     scene->SaveStateForUndo();
 
+    vtkDebugMacro("Setting scene info");
     scalarNode->SetScene(scene);
     scalarNode->SetDescription("Received by OpenIGTLink");
 
     displayNode->SetScene(scene);
 
+
+    ///double range[2];
+    vtkDebugMacro("Set basic display info");
     //scalarNode->GetImageData()->GetScalarRange(range);
     //range[0] = 0.0;
     //range[1] = 256.0;
@@ -129,6 +137,7 @@ vtkMRMLNode* vtkIGTLToMRMLImage::CreateNewNodeWithMessage(vtkMRMLScene* scene, c
     //displayNode->SetWindow(range[1] - range[0]);
     //displayNode->SetLevel(0.5 * (range[1] + range[0]) );
 
+    vtkDebugMacro("Adding node..");
     scene->AddNode(displayNode);
 
     //displayNode->SetDefaultColorMap();
@@ -286,9 +295,13 @@ int vtkIGTLToMRMLImage::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNod
     newImageData->SetExtent(0, size[0]-1, 0, size[1]-1, 0, size[2]-1);
     newImageData->SetOrigin(0.0, 0.0, 0.0);
     newImageData->SetSpacing(1.0, 1.0, 1.0);
+#if (VTK_MAJOR_VERSION <= 5)
     newImageData->SetNumberOfScalarComponents(numComponents);
     newImageData->SetScalarType(scalarType);
     newImageData->AllocateScalars();
+#else
+    newImageData->AllocateScalars(scalarType, numComponents);
+#endif
     imageData = newImageData;
     }
 

--- a/MRML/vtkIGTLToMRMLImage.h
+++ b/MRML/vtkIGTLToMRMLImage.h
@@ -35,7 +35,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImage : public vt
  public:
 
   static vtkIGTLToMRMLImage *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLImage,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLImage,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLImageMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLImageMetaList.cxx
@@ -34,7 +34,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLImageMetaList);
-vtkCxxRevisionMacro(vtkIGTLToMRMLImageMetaList, "$Revision: 10577 $");
 
 //---------------------------------------------------------------------------
 vtkIGTLToMRMLImageMetaList::vtkIGTLToMRMLImageMetaList()

--- a/MRML/vtkIGTLToMRMLImageMetaList.h
+++ b/MRML/vtkIGTLToMRMLImageMetaList.h
@@ -32,7 +32,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImageMetaList : p
  public:
 
   static vtkIGTLToMRMLImageMetaList *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLImageMetaList,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLImageMetaList,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLLabelMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLLabelMetaList.cxx
@@ -30,7 +30,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLLabelMetaList);
-vtkCxxRevisionMacro(vtkIGTLToMRMLLabelMetaList, "$Revision: 10577 $");
 
 //---------------------------------------------------------------------------
 vtkIGTLToMRMLLabelMetaList::vtkIGTLToMRMLLabelMetaList()

--- a/MRML/vtkIGTLToMRMLLabelMetaList.h
+++ b/MRML/vtkIGTLToMRMLLabelMetaList.h
@@ -29,7 +29,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLLabelMetaList : p
  public:
 
   static vtkIGTLToMRMLLabelMetaList *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLLabelMetaList,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLLabelMetaList,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLLinearTransform.cxx
+++ b/MRML/vtkIGTLToMRMLLinearTransform.cxx
@@ -43,7 +43,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLLinearTransform);
-vtkCxxRevisionMacro(vtkIGTLToMRMLLinearTransform, "$Revision: 15552 $");
 
 
 //---------------------------------------------------------------------------
@@ -303,7 +302,11 @@ vtkMRMLModelNode* vtkIGTLToMRMLLinearTransform::AddLocatorModel(vtkMRMLScene * s
   trans->RotateX(90.0);
   trans->Translate(0.0, -50.0, 0.0);
   trans->Update();
+#if (VTK_MAJOR_VERSION <= 5)
   tfilter->SetInput(cylinder->GetOutput());
+#else
+  tfilter->SetInputConnection(cylinder->GetOutputPort());
+#endif
   tfilter->SetTransform(trans);
   tfilter->Update();
 
@@ -314,9 +317,14 @@ vtkMRMLModelNode* vtkIGTLToMRMLLinearTransform::AddLocatorModel(vtkMRMLScene * s
   sphere->Update();
 
   vtkAppendPolyData *apd = vtkAppendPolyData::New();
+#if (VTK_MAJOR_VERSION <= 5)
   apd->AddInput(sphere->GetOutput());
   //apd->AddInput(cylinder->GetOutput());
   apd->AddInput(tfilter->GetOutput());
+#else
+  apd->AddInputConnection(sphere->GetOutputPort());
+  apd->AddInputConnection(tfilter->GetOutputPort());
+#endif
   apd->Update();
 
   locatorModel->SetAndObservePolyData(apd->GetOutput());

--- a/MRML/vtkIGTLToMRMLLinearTransform.h
+++ b/MRML/vtkIGTLToMRMLLinearTransform.h
@@ -36,7 +36,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLLinearTransform :
  public:
 
   static vtkIGTLToMRMLLinearTransform *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLLinearTransform,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLLinearTransform,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLPointMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLPointMetaList.cxx
@@ -26,7 +26,6 @@
 #include <vtkObjectFactory.h>
 
 vtkStandardNewMacro(vtkIGTLToMRMLPointMetaList);
-vtkCxxRevisionMacro(vtkIGTLToMRMLPointMetaList, "$Revision: 10577 $");
 
 
 //---------------------------------------------------------------------------

--- a/MRML/vtkIGTLToMRMLPointMetaList.h
+++ b/MRML/vtkIGTLToMRMLPointMetaList.h
@@ -27,7 +27,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPointMetaList : p
  public:
 
   static vtkIGTLToMRMLPointMetaList *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLPointMetaList,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLPointMetaList,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLPosition.cxx
+++ b/MRML/vtkIGTLToMRMLPosition.cxx
@@ -34,7 +34,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLPosition);
-vtkCxxRevisionMacro(vtkIGTLToMRMLPosition, "$Revision: 15552 $");
 
 //---------------------------------------------------------------------------
 vtkIGTLToMRMLPosition::vtkIGTLToMRMLPosition()

--- a/MRML/vtkIGTLToMRMLPosition.h
+++ b/MRML/vtkIGTLToMRMLPosition.h
@@ -33,7 +33,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPosition : public
  public:
 
   static vtkIGTLToMRMLPosition *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLPosition,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLPosition,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 

--- a/MRML/vtkIGTLToMRMLTrackingData.cxx
+++ b/MRML/vtkIGTLToMRMLTrackingData.cxx
@@ -33,7 +33,6 @@
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIGTLToMRMLTrackingData);
-vtkCxxRevisionMacro(vtkIGTLToMRMLTrackingData, "$Revision: 10577 $");
 
 
 //---------------------------------------------------------------------------

--- a/MRML/vtkIGTLToMRMLTrackingData.h
+++ b/MRML/vtkIGTLToMRMLTrackingData.h
@@ -35,7 +35,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLTrackingData : pu
  public:
 
   static vtkIGTLToMRMLTrackingData *New();
-  vtkTypeRevisionMacro(vtkIGTLToMRMLTrackingData,vtkObject);
+  vtkTypeMacro(vtkIGTLToMRMLTrackingData,vtkObject);
 
   void PrintSelf(ostream& os, vtkIndent indent);
 


### PR DESCRIPTION
1) Remove deprecated Macro.
The following two macros were deprecated in VTK 5.0 that were still supported, but have now been eliminated:
vtkTypeRevisionMacro has been replaced with vtkTypeMacro; vtkCxxRevisionMacro has been removed.
http://www.visitusers.org/index.php?title=VTK_6.0_Upgrade

2) Replace SetInput() with SetInputData() and SetInputConnection(), the same kind of functions include SetInput1(), SetInput2(), AddInput() and SetSource().
http://www.vtk.org/Wiki/VTK/VTK_6_Migration/Replacement_of_SetInput

3) Change scalars manipulation functions
http://www.vtk.org/Wiki/VTK/VTK_6_Migration/Changes_to_Scalars_Manipulation_Functions.
http://vtk.org/Wiki/VTK/VTK6/Migration/WikiExamples#Improve.

4) Remove Pipeline Update Methods from vtkDataObject.
http://www.vtk.org/Wiki/VTK/VTK_6_Migration/Removal_of_Update.
