### PR TITLE
ENH: Prevent continuous changing of connector node state while waiting for connection

### DIFF
--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -657,7 +657,7 @@ void* vtkMRMLIGTLConnectorNode::ThreadFunction(void* ptr)
     //igtlcon->Socket = igtlcon->WaitForConnection();
     igtlcon->WaitForConnection();
     igtlcon->Mutex->Unlock();
-    if (igtlcon->Socket.IsNotNull())
+    if (igtlcon->Socket->GetConnected())
       {
       igtlcon->State = STATE_CONNECTED;
       // need to Request the InvokeEvent, because we are not on the main thread now


### PR DESCRIPTION
This is a fix for big performance issue in PlusRemote: Slicer basically hangs if it is in waiting-for-connection state for a a few minutes because OpenIGTLinkIF constantly changes the state of the connector node while waiting for connection.

Root cause: igtlcon->WaitForConnection() does not delete the socket, just closes it, so (igtlcon->Socket.IsNotNull()) is always true. This causes a STATE_WAIT_CONNECTED and STATE_WAIT_CONNECTION state change at each reconnect attempt, which results unnecessary Modified event invocations.

Instead, (igtlcon->Socket->GetConnected()) should be called to see if a client/server is connected successfully.

Tested on Windows in both client and server modes.
