### PR TITLE
Fix an other sign-compare warnings in vtkIGTLToMRMLPolyData::IGTLToMRML

### DIFF
--- a/MRML/vtkIGTLToMRMLPolyData.cxx
+++ b/MRML/vtkIGTLToMRMLPolyData.cxx
@@ -396,7 +396,7 @@ int vtkIGTLToMRMLPolyData::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode
       if (npoints > 0)
         {
         igtl::PolyDataPointArray::Pointer pointArray = igtl::PolyDataPointArray::New();
-        for (unsigned int i = 0; i < npoints; i ++)
+        for (int i = 0; i < npoints; i ++)
           {
           double *p = points->GetPoint(i);
           pointArray->AddPoint(static_cast<igtlFloat32>(p[0]),


### PR DESCRIPTION
This commit fixes the following warning:

```
/path/to/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPolyData.cxx: In member function ‘virtual int vtkIGTLToMRMLPolyData::MRMLToIGTL(long unsigned int, vtkMRMLNode*, int*, void**)’:
/path/to/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPolyData.cxx:399:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (unsigned int i = 0; i < npoints; i ++)
                                      ^
```