### PR TITLE
ENH: Enhancements for better OpenIGTLink string command support

### DIFF
--- a/Logic/vtkSlicerOpenIGTLinkIFLogic.cxx
+++ b/Logic/vtkSlicerOpenIGTLinkIFLogic.cxx
@@ -21,6 +21,7 @@
 #include "vtkMRMLIGTLConnectorNode.h"
 #include "vtkMRMLImageMetaListNode.h"
 #include "vtkMRMLLabelMetaListNode.h"
+#include "vtkMRMLTextNode.h"
 #include "vtkMRMLIGTLTrackingDataQueryNode.h"
 #include "vtkMRMLIGTLTrackingDataBundleNode.h"
 #include "vtkMRMLIGTLQueryNode.h"
@@ -190,6 +191,7 @@ void vtkSlicerOpenIGTLinkIFLogic::RegisterNodes()
   scene->RegisterNodeClass(vtkNew<vtkMRMLIGTLConnectorNode>().GetPointer());
   scene->RegisterNodeClass(vtkNew<vtkMRMLImageMetaListNode>().GetPointer());
   scene->RegisterNodeClass(vtkNew<vtkMRMLLabelMetaListNode>().GetPointer());
+  scene->RegisterNodeClass(vtkNew<vtkMRMLTextNode>().GetPointer());
   scene->RegisterNodeClass(vtkNew<vtkMRMLIGTLTrackingDataQueryNode>().GetPointer());
   scene->RegisterNodeClass(vtkNew<vtkMRMLIGTLTrackingDataBundleNode>().GetPointer());
   scene->RegisterNodeClass(vtkNew<vtkMRMLIGTLStatusNode>().GetPointer());

--- a/MRML/CMakeLists.txt
+++ b/MRML/CMakeLists.txt
@@ -34,6 +34,7 @@ if(OpenIGTLink_PROTOCOL_VERSION EQUAL 2)
     vtkMRMLIGTLQueryNode.cxx
     vtkMRMLImageMetaListNode.cxx
     vtkMRMLLabelMetaListNode.cxx
+    vtkMRMLTextNode.cxx
     vtkIGTLToMRMLPoints.cxx
     vtkIGTLToMRMLPolyData.cxx
     vtkIGTLToMRMLImageMetaList.cxx

--- a/MRML/vtkIGTLToMRMLImage.cxx
+++ b/MRML/vtkIGTLToMRMLImage.cxx
@@ -683,14 +683,7 @@ int vtkIGTLToMRMLImage::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, i
           {
           this->GetImageMessage = igtl::GetImageMessage::New();
           }
-        if (qnode->GetNoNameQuery() == 1)
-          {
-          this->GetImageMessage->SetDeviceName("");
-          }
-        else
-          {
-          this->GetImageMessage->SetDeviceName(mrmlNode->GetName());
-          }
+        this->GetImageMessage->SetDeviceName(qnode->GetIGTLDeviceName());
         this->GetImageMessage->Pack();
         *size = this->GetImageMessage->GetPackSize();
         *igtlMsg = this->GetImageMessage->GetPackPointer();

--- a/MRML/vtkIGTLToMRMLImageMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLImageMetaList.cxx
@@ -178,14 +178,7 @@ int vtkIGTLToMRMLImageMetaList::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrm
           {
           this->GetImageMetaMessage = igtl::GetImageMetaMessage::New();
           }
-        if (qnode->GetNoNameQuery())
-          {
-          this->GetImageMetaMessage->SetDeviceName("");
-          }
-        else
-          {
-          this->GetImageMetaMessage->SetDeviceName(mrmlNode->GetName());
-          }
+        this->GetImageMetaMessage->SetDeviceName(qnode->GetIGTLDeviceName());
         this->GetImageMetaMessage->Pack();
         *size = this->GetImageMetaMessage->GetPackSize();
         *igtlMsg = this->GetImageMetaMessage->GetPackPointer();

--- a/MRML/vtkIGTLToMRMLLabelMetaList.cxx
+++ b/MRML/vtkIGTLToMRMLLabelMetaList.cxx
@@ -162,14 +162,7 @@ int vtkIGTLToMRMLLabelMetaList::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrm
           {
           this->GetLabelMetaMessage = igtl::GetLabelMetaMessage::New();
           }
-        if (qnode->GetNoNameQuery())
-          {
-          this->GetLabelMetaMessage->SetDeviceName("");
-          }
-        else
-          {
-          this->GetLabelMetaMessage->SetDeviceName(mrmlNode->GetName());
-          }
+        this->GetLabelMetaMessage->SetDeviceName(qnode->GetIGTLDeviceName());
         this->GetLabelMetaMessage->Pack();
         *size = this->GetLabelMetaMessage->GetPackSize();
         *igtlMsg = this->GetLabelMetaMessage->GetPackPointer();

--- a/MRML/vtkIGTLToMRMLPoints.cxx
+++ b/MRML/vtkIGTLToMRMLPoints.cxx
@@ -235,23 +235,16 @@ int vtkIGTLToMRMLPoints::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, 
     if (qnode)
       {
       if (qnode->GetQueryType() == vtkMRMLIGTLQueryNode::TYPE_GET)
-       {
-       if (this->GetPointMsg.IsNull())
+        {
+        if (this->GetPointMsg.IsNull())
           {
           this->GetPointMsg = igtl::GetPointMessage::New();
           }
-        if (qnode->GetNoNameQuery())
-          {
-          this->GetPointMsg->SetDeviceName("");
-          }
-        else
-          {
-          this->GetPointMsg->SetDeviceName(mrmlNode->GetName());
-          }
-				this->GetPointMsg->Pack();
+        this->GetPointMsg->SetDeviceName(qnode->GetIGTLDeviceName());
+        this->GetPointMsg->Pack();
         *size = this->GetPointMsg->GetPackSize();
 
-	      *igtlMsg = this->GetPointMsg->GetPackPointer();
+        *igtlMsg = this->GetPointMsg->GetPackPointer();
         return 1;
         }
       else if (qnode->GetQueryType() == vtkMRMLIGTLQueryNode::TYPE_START)

--- a/MRML/vtkIGTLToMRMLPolyData.cxx
+++ b/MRML/vtkIGTLToMRMLPolyData.cxx
@@ -501,14 +501,7 @@ int vtkIGTLToMRMLPolyData::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode
           {
           this->GetPolyDataMessage = igtl::GetPolyDataMessage::New();
           }
-        if (qnode->GetNoNameQuery() == 1)
-          {
-          this->GetPolyDataMessage->SetDeviceName("");
-          }
-        else
-          {
-          this->GetPolyDataMessage->SetDeviceName(mrmlNode->GetName());
-          }
+        this->GetPolyDataMessage->SetDeviceName(qnode->GetIGTLDeviceName());
         this->GetPolyDataMessage->Pack();
         *size = this->GetPolyDataMessage->GetPackSize();
         *igtlMsg = this->GetPolyDataMessage->GetPackPointer();

--- a/MRML/vtkIGTLToMRMLString.h
+++ b/MRML/vtkIGTLToMRMLString.h
@@ -31,7 +31,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLString : public v
 
   virtual int          GetConverterType() { return TYPE_NORMAL; };
   virtual const char*  GetIGTLName() { return "STRING"; };
-  virtual const char*  GetMRMLName() { return "AnnotationText"; };
+  virtual const char*  GetMRMLName() { return "Text"; };
   virtual vtkIntArray* GetNodeEvents();
   virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
 

--- a/MRML/vtkIGTLToMRMLTrackingData.cxx
+++ b/MRML/vtkIGTLToMRMLTrackingData.cxx
@@ -24,7 +24,6 @@
 #include <vtkMRMLScalarVolumeNode.h>
 
 // VTK includes
-#include <vtkImageData.h>
 #include <vtkIntArray.h>
 #include <vtkObjectFactory.h>
 
@@ -148,17 +147,6 @@ int vtkIGTLToMRMLTrackingData::MRMLToIGTL(unsigned long vtkNotUsed(event), vtkMR
       {
       if (qnode->GetQueryType() == vtkMRMLIGTLQueryNode::TYPE_GET)
         {
-        /*
-        //igtl::TransformMessage::Pointer OutTransformMsg;
-        if (this->GetImageMetaMessage.IsNull())
-          {
-          this->GetImageMetaMessage = igtl::GetTransformDataMessage::New();
-          }
-        this->GetImageMetaMessage->SetDeviceName(mrmlNode->GetName());
-        this->GetImageMetaMessage->Pack();
-        *size = this->GetImageMetaMessage->GetPackSize();
-        *igtlMsg = this->GetImageMetaMessage->GetPackPointer();
-        */
         *size = 0;
         return 0;
         }
@@ -168,15 +156,7 @@ int vtkIGTLToMRMLTrackingData::MRMLToIGTL(unsigned long vtkNotUsed(event), vtkMR
           {
           this->StartTrackingDataMessage = igtl::StartTrackingDataMessage::New();
           }
-        //this->StartTrackingDataMessage->SetDeviceName(mrmlNode->GetName());
-        if (qnode->GetNoNameQuery())
-          {
-          this->StartTrackingDataMessage->SetDeviceName("");
-          }
-        else
-          {
-          this->StartTrackingDataMessage->SetDeviceName(mrmlNode->GetName());
-          }
+        this->StartTrackingDataMessage->SetDeviceName(qnode->GetIGTLDeviceName());
         this->StartTrackingDataMessage->SetResolution(50);
         this->StartTrackingDataMessage->SetCoordinateName("");
         this->StartTrackingDataMessage->Pack();
@@ -190,14 +170,7 @@ int vtkIGTLToMRMLTrackingData::MRMLToIGTL(unsigned long vtkNotUsed(event), vtkMR
           {
           this->StopTrackingDataMessage = igtl::StopTrackingDataMessage::New();
           }
-        if (qnode->GetNoNameQuery())
-          {
-          this->StopTrackingDataMessage->SetDeviceName("");
-          }
-        else
-          {
-          this->StopTrackingDataMessage->SetDeviceName(mrmlNode->GetName());
-          }
+        this->StopTrackingDataMessage->SetDeviceName(qnode->GetIGTLDeviceName());
         this->StopTrackingDataMessage->Pack();
         *size = this->StopTrackingDataMessage->GetPackSize();
         *igtlMsg = this->StopTrackingDataMessage->GetPackPointer();
@@ -210,18 +183,6 @@ int vtkIGTLToMRMLTrackingData::MRMLToIGTL(unsigned long vtkNotUsed(event), vtkMR
       return 0;
       }
     }
-
-  // If mrmlNode is data node
-  /*
-  if (event == vtkMRMLVolumeNode::ImageDataModifiedEvent)
-    {
-    return 1;
-    }
-  else
-    {
-    return 0;
-    }
-  */
   return 0;
 }
 

--- a/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/MRML/vtkMRMLIGTLConnectorNode.h
@@ -31,6 +31,7 @@
 // VTK includes
 #include <vtkObject.h>
 #include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
 
 // STD includes
 #include <string>
@@ -292,6 +293,10 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   // Push query int the query list.
   void PushQuery(vtkMRMLIGTLQueryNode* query);
 
+  // Description:
+  // Removes query from the query list.
+  void CancelQuery(vtkMRMLIGTLQueryNode* node);
+
   //----------------------------------------------------------------
   // For OpenIGTLink time stamp access
   //----------------------------------------------------------------
@@ -390,7 +395,8 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   // Query queueing mechanism is needed to send all queries from the connector thread.
   // Queries can be pushed to the end of the QueryQueue by calling RequestInvoke from any thread,
   // and they will be Invoked in the main thread.
-  std::list<vtkMRMLIGTLQueryNode*> QueryWaitingQueue;
+  // Use a weak pointer to make sure we don't try to access the query node after it is deleted from the scene.
+  std::list< vtkWeakPointer<vtkMRMLIGTLQueryNode> > QueryWaitingQueue;
   vtkMutexLock* QueryQueueMutex;
 
   // Flag for the push outoing message request

--- a/MRML/vtkMRMLIGTLQueryNode.cxx
+++ b/MRML/vtkMRMLIGTLQueryNode.cxx
@@ -14,6 +14,7 @@ Version:   $Revision: 1.2 $
 
 // OpenIGTLinkIF MRML includes
 #include "vtkMRMLIGTLQueryNode.h"
+#include "vtkMRMLIGTLConnectorNode.h"
 
 // OpenIGTLink includes
 #include <igtlOSUtil.h>
@@ -26,12 +27,16 @@ Version:   $Revision: 1.2 $
 
 // VTK includes
 #include <vtkObjectFactory.h>
+#include <vtkTimerLog.h>
 
 // STD includes
 #include <string>
 #include <iostream>
 #include <sstream>
 #include <map>
+
+static const char ResponseDataNodeRole[] = "responseData";
+static const char ConnectorNodeRole[] = "connector";
 
 //------------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLIGTLQueryNode);
@@ -42,13 +47,11 @@ vtkMRMLIGTLQueryNode::vtkMRMLIGTLQueryNode()
   this->QueryStatus = 0;
   this->QueryType   = 0;
 
-  this->ConnectorNodeID = "";
-
   this->TimeStamp = 0.0;
   this->TimeOut   = 0.0;
 
-  this->NoNameQuery = 0;
-
+  this->AddNodeReferenceRole(ResponseDataNodeRole);
+  this->AddNodeReferenceRole(ConnectorNodeRole);
 }
 
 //----------------------------------------------------------------------------
@@ -82,41 +85,128 @@ void vtkMRMLIGTLQueryNode::Copy(vtkMRMLNode *anode)
 {
 
   Superclass::Copy(anode);
-  //vtkMRMLIGTLQueryNode *node = (vtkMRMLIGTLQueryNode *) anode;
 
+  vtkMRMLIGTLQueryNode* node = vtkMRMLIGTLQueryNode::SafeDownCast(anode);
+  if (node==NULL)
+  {
+    vtkErrorMacro("vtkMRMLIGTLQueryNode::Copy failed: unrelated input node type");
+    return;
+  }
+
+  this->IGTLName = node->IGTLName;
+  this->IGTLDeviceName = node->IGTLDeviceName;
+  this->QueryStatus = node->QueryStatus;
+  this->QueryType = node->QueryType;
+  this->TimeStamp = node->TimeStamp;
+  this->TimeOut = node->TimeOut;
 }
-
-
-//----------------------------------------------------------------------------
-void vtkMRMLIGTLQueryNode::ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData )
-{
-
-  Superclass::ProcessMRMLEvents(caller, event, callData);
-
-}
-
 
 //----------------------------------------------------------------------------
 void vtkMRMLIGTLQueryNode::PrintSelf(ostream& os, vtkIndent indent)
 {
-  vtkMRMLNode::PrintSelf(os,indent);
+  Superclass::PrintSelf(os,indent);
+
+  os << indent << "IGTLName: " << this->IGTLName << "\n";
+  os << indent << "IGTLDeviceName: " << this->IGTLDeviceName << "\n";
+  os << indent << "QueryType: " << vtkMRMLIGTLQueryNode::QueryTypeToString(this->QueryType) << "\n";
+  os << indent << "QueryStatus: " << vtkMRMLIGTLQueryNode::QueryStatusToString(this->QueryStatus) << "\n";
+  if (this->TimeOut>0 && this->QueryStatus==STATUS_WAITING)
+  {
+    double remainingTime = this->TimeOut - (vtkTimerLog::GetUniversalTime()-this->TimeStamp);
+    os << indent << indent << "Remaining time: " << remainingTime << "\n";
+  }
+  os << indent << "TimeStamp: " << this->TimeStamp << "\n";
+  os << indent << "TimeOut: " << this->TimeOut << "\n";
+  os << indent << "ConnectorNodeID: " << (this->GetConnectorNodeID()?this->GetConnectorNodeID():"(none)") << "\n";
+  os << indent << "DataNodeID: " << (this->GetResponseDataNodeID()?this->GetResponseDataNodeID():"(none)") << "\n";
 }
 
 
 //----------------------------------------------------------------------------
 void vtkMRMLIGTLQueryNode::SetIGTLName(const char* name)
 {
-  char buf[IGTL_HEADER_DEVSIZE+1];
-  buf[IGTL_HEADER_DEVSIZE] = '\0';
-  strncpy(buf, name, IGTL_HEADER_DEVSIZE);
+  char buf[IGTL_HEADER_TYPE_SIZE+1];
+  buf[IGTL_HEADER_TYPE_SIZE] = '\0';
+  strncpy(buf, name, IGTL_HEADER_TYPE_SIZE);
   this->IGTLName = buf;
-
 }
 
+//----------------------------------------------------------------------------
+void vtkMRMLIGTLQueryNode::SetIGTLDeviceName(const char* name)
+{
+  char buf[IGTL_HEADER_NAME_SIZE+1];
+  buf[IGTL_HEADER_NAME_SIZE] = '\0';
+  strncpy(buf, name, IGTL_HEADER_NAME_SIZE);
+  this->IGTLDeviceName = buf;
+}
 
 //----------------------------------------------------------------------------
 const char* vtkMRMLIGTLQueryNode::GetErrorString()
 {
   return "";
+}
 
+//----------------------------------------------------------------------------
+const char* vtkMRMLIGTLQueryNode::QueryStatusToString(int queryStatus)
+{
+  switch (queryStatus)
+  {
+    case STATUS_NOT_DEFINED: return "NOT_DEFINED";
+    case STATUS_PREPARED: return "PREPARED";
+    case STATUS_WAITING: return "WAITING";
+    case STATUS_SUCCESS: return "SUCCESS";
+    case STATUS_EXPIRED: return "EXPIRED";
+    default:
+      return "INVALID";
+  }
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLIGTLQueryNode::QueryTypeToString(int queryType)
+{
+  switch (queryType)
+  {
+    case TYPE_NOT_DEFINED: return "NOT_DEFINED";
+    case TYPE_GET: return "GET";
+    case TYPE_START: return "START";
+    case TYPE_STOP: return "STOP";
+    default:
+      return "INVALID";
+  }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLIGTLQueryNode::SetResponseDataNodeID(const char* id)
+{
+  this->SetNodeReferenceID(ResponseDataNodeRole, id);
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLIGTLQueryNode::GetResponseDataNodeID()
+{
+  return GetNodeReferenceID(ResponseDataNodeRole);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLIGTLQueryNode::GetResponseDataNode()
+{
+  return GetNodeReference(ResponseDataNodeRole);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLIGTLQueryNode::SetConnectorNodeID(const char* id)
+{
+  this->SetNodeReferenceID(ConnectorNodeRole, id);
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLIGTLQueryNode::GetConnectorNodeID()
+{
+  return GetNodeReferenceID(ConnectorNodeRole);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLIGTLConnectorNode* vtkMRMLIGTLQueryNode::GetConnectorNode()
+{
+  return vtkMRMLIGTLConnectorNode::SafeDownCast(GetNodeReference(ConnectorNodeRole));
 }

--- a/MRML/vtkMRMLTextNode.cxx
+++ b/MRML/vtkMRMLTextNode.cxx
@@ -1,5 +1,6 @@
 #include "vtkObjectFactory.h"
 #include "vtkMRMLTextNode.h"
+#include "vtkXMLUtilities.h"
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLTextNode);
@@ -31,7 +32,7 @@ void vtkMRMLTextNode::ReadXMLAttributes(const char** atts)
     attValue = *(atts++);
     if (!strcmp(attName, "text"))
       {
-      this->SetText( vtkMRMLNode::URLDecodeString(attValue) );
+      this->SetText(attValue);
       }
     else if (!strcmp(attName, "encoding"))
       {
@@ -63,7 +64,8 @@ void vtkMRMLTextNode::WriteXML(ostream& of, int nIndent)
   of << indent << " text=\"";
   if (this->GetText()!=NULL)
   {
-    of << vtkMRMLNode::URLEncodeString(this->GetText());
+    // Write to XML, encoding special characters, such as " ' \ < > &
+    vtkXMLUtilities::EncodeString(this->GetText(), VTK_ENCODING_NONE, of, VTK_ENCODING_NONE, 1 /* encode special characters */ );
   }
   of << "\"";
 

--- a/MRML/vtkMRMLTextNode.cxx
+++ b/MRML/vtkMRMLTextNode.cxx
@@ -90,7 +90,7 @@ void vtkMRMLTextNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 
-  os << "Text: " << ( (this->GetText()) ? this->GetText() : "None" ) << "\n";
+  os << "Text: " << ( (this->GetText()) ? this->GetText() : "(none)" ) << "\n";
   os << "Encoding: " << this->GetEncoding() << "\n";
 }
 

--- a/MRML/vtkMRMLTextNode.cxx
+++ b/MRML/vtkMRMLTextNode.cxx
@@ -1,0 +1,94 @@
+#include "vtkObjectFactory.h"
+#include "vtkMRMLTextNode.h"
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLTextNode);
+
+//-----------------------------------------------------------------------------
+vtkMRMLTextNode::vtkMRMLTextNode()
+{
+  this->Text = NULL;
+  this->Encoding = ENCODING_US_ASCII;
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLTextNode::~vtkMRMLTextNode()
+{
+  this->SetText(NULL);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTextNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+  Superclass::ReadXMLAttributes(atts);
+
+  const char* attName;
+  const char* attValue;
+  while (*atts != NULL)
+    {
+    attName = *(atts++);
+    attValue = *(atts++);
+    if (!strcmp(attName, "text"))
+      {
+      this->SetText( vtkMRMLNode::URLDecodeString(attValue) );
+      }
+    else if (!strcmp(attName, "encoding"))
+      {
+      std::stringstream ss;
+      ss << attValue;
+      int encoding=0;
+      ss >> encoding;
+      if (encoding>=3)
+        {
+        this->SetEncoding(encoding);
+        }
+      else
+        {
+        vtkErrorMacro("Failed to set encoding. Invalid input value: "<<attValue);
+        }
+      }
+    }
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTextNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  vtkIndent indent(nIndent);
+
+  of << indent << " text=\"";
+  if (this->GetText()!=NULL)
+  {
+    of << vtkMRMLNode::URLEncodeString(this->GetText());
+  }
+  of << "\"";
+
+  of << indent << " encoding=\"" << this->GetEncoding() << "\"";
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTextNode::Copy(vtkMRMLNode *anode)
+{
+  int disabledModify = this->StartModify();
+  Superclass::Copy(anode);
+  vtkMRMLTextNode *node = vtkMRMLTextNode::SafeDownCast(anode);
+
+  this->SetText(node->GetText());
+  this->SetEncoding(node->GetEncoding());
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTextNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+
+  os << "Text: " << ( (this->GetText()) ? this->GetText() : "None" ) << "\n";
+  os << "Encoding: " << this->GetEncoding() << "\n";
+}
+

--- a/MRML/vtkMRMLTextNode.h
+++ b/MRML/vtkMRMLTextNode.h
@@ -1,0 +1,70 @@
+#ifndef __vtkMRMLTextNode_h
+#define __vtkMRMLTextNode_h
+
+// OpenIGTLinkIF MRML includes
+#include "vtkIGTLToMRMLBase.h"
+#include "vtkSlicerOpenIGTLinkIFModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLNode.h>
+
+// VTK includes
+#include <vtkStdString.h>
+
+class  VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLTextNode : public vtkMRMLNode
+{
+public:
+  enum
+  {
+    ENCODING_US_ASCII = 3,
+    ENCODING_ISO_8859_1 = 4,
+    ENCODING_LATIN1 = ENCODING_ISO_8859_1 // alias
+    // see other codes at http://www.iana.org/assignments/character-sets/character-sets.xhtml
+  };
+
+  static vtkMRMLTextNode *New();
+  vtkTypeMacro(vtkMRMLTextNode,vtkMRMLNode);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+  virtual vtkMRMLNode* CreateNodeInstance();
+  
+  ///
+  /// Set node attributes
+  virtual void ReadXMLAttributes( const char** atts);
+
+  ///
+  /// Write this node's information to a MRML file in XML format.
+  virtual void WriteXML(ostream& of, int indent);
+
+  ///
+  /// Copy the node's attributes to this object
+  virtual void Copy(vtkMRMLNode *node);
+
+  ///
+  /// Get node XML tag name (like Volume, Model)
+  virtual const char* GetNodeTagName() {return "Text";};
+
+  ///
+  /// Set text encoding
+  vtkSetStringMacro(Text);
+  vtkGetStringMacro(Text);
+
+  ///
+  /// Set encoding of the text
+  /// For character encoding, please refer IANA Character Sets
+  /// (http://www.iana.org/assignments/character-sets/character-sets.xhtml)
+  /// Default is US-ASCII (ANSI-X3.4-1968; MIBenum = 3).
+  vtkSetMacro (Encoding, int);
+  vtkGetMacro (Encoding, int);
+
+protected:
+  vtkMRMLTextNode();
+  ~vtkMRMLTextNode();
+  vtkMRMLTextNode(const vtkMRMLTextNode&);
+  void operator=(const vtkMRMLTextNode&);
+
+  char* Text;
+  int Encoding;
+};
+
+#endif


### PR DESCRIPTION
* Use simple vtkMRMLTextNode instead of vtkMRMLAnnotationTextNode
* Implemented query timeout (timeout was already in the query node but it was not used): state of the query changes to TIMEOUT if allowed time is expired
* Allow the query node to have any name: IGTLDeviceName attribute is used instead of the node Name for matching with incoming nodes (NoNameQuery is not needed anymore, IGTLDeviceName can be set to empty instead)
* Use node references in vtkMRMLIGTLQueryNode instead of storing node IDs
* Implemented query for STRING commands: if a STRING query node contains CommandDeviceName and CommandString attributes then a STRING message is sent out with this content as a query
