### PR TITLE
ENH: Show text nodes (vtkMRMLTextNode) on the list of potential outgoing nodes

### DIFF
--- a/Resources/UI/qSlicerIGTLIONodeSelectorWidget.ui
+++ b/Resources/UI/qSlicerIGTLIONodeSelectorWidget.ui
@@ -40,6 +40,7 @@
        <string>vtkMRMLScalarVolumeNode</string>
        <string>vtkMRMLMarkupsFiducialNode</string>
        <string>vtkMRMLModelNode</string>
+       <string>vtkMRMLTextNode</string>
       </stringlist>
      </property>
      <property name="addEnabled">


### PR DESCRIPTION
Minor change to allow users to choose a vtkMRMLTextNode on the OpenIGTLinkIF GUI as an outgoing node.