### PR TITLE
BUG: Fixed crash on disconnect in server mode

### DIFF
--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -664,7 +664,7 @@ void* vtkMRMLIGTLConnectorNode::ThreadFunction(void* ptr)
     //igtlcon->Socket = igtlcon->WaitForConnection();
     igtlcon->WaitForConnection();
     igtlcon->Mutex->Unlock();
-    if (igtlcon->Socket->GetConnected())
+    if (igtlcon->Socket.IsNotNull() && igtlcon->Socket->GetConnected())
       {
       igtlcon->State = STATE_CONNECTED;
       // need to Request the InvokeEvent, because we are not on the main thread now


### PR DESCRIPTION
This fixes a Slicer crash caused by deactivating an OpenIGTLink connector in server mode while sending data to a client.