### PR TITLE
 Fix for issues #54, #55 and #56

### DIFF
--- a/MRML/vtkIGTLToMRMLImage.cxx
+++ b/MRML/vtkIGTLToMRMLImage.cxx
@@ -580,12 +580,12 @@ int vtkIGTLToMRMLImage::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, i
     int   scalarType;       // scalar type
     //double *origin;
     double *spacing;       // spacing (mm/pixel)
-    //int   ncomp;
+    int   ncomp;
     int   svoffset[] = {0, 0, 0};           // sub-volume offset
     int   endian;
 
     scalarType = imageData->GetScalarType();
-    //ncomp = imageData->GetNumberOfScalarComponents();
+    ncomp = imageData->GetNumberOfScalarComponents();
     imageData->GetDimensions(isize);
     //imageData->GetExtent(0, isize[0]-1, 0, isize[1]-1, 0, isize[2]-1);
     //origin = imageData->GetOrigin();
@@ -608,6 +608,7 @@ int vtkIGTLToMRMLImage::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, i
     this->OutImageMessage->SetEndian(endian);
     this->OutImageMessage->SetDeviceName(volumeNode->GetName());
     this->OutImageMessage->SetSubVolume(isize, svoffset);
+    this->OutImageMessage->SetNumComponents(ncomp);
     this->OutImageMessage->AllocateScalars();
 
     memcpy(this->OutImageMessage->GetScalarPointer(),

--- a/MRML/vtkIGTLToMRMLPolyData.cxx
+++ b/MRML/vtkIGTLToMRMLPolyData.cxx
@@ -183,7 +183,7 @@ int vtkIGTLToMRMLPolyData::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRML
 
   // Vertices
   igtl::PolyDataCellArray::Pointer verticesArray =  polyDataMsg->GetVertices();
-  int nvertices = verticesArray->GetNumberOfCells();
+  int nvertices = verticesArray.IsNotNull() ? verticesArray->GetNumberOfCells() : 0;
   if (nvertices > 0)
     {
     vtkSmartPointer<vtkCellArray> vertCells = vtkSmartPointer<vtkCellArray>::New();
@@ -206,7 +206,7 @@ int vtkIGTLToMRMLPolyData::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRML
 
   // Lines
   igtl::PolyDataCellArray::Pointer linesArray = polyDataMsg->GetLines();
-  int nlines = linesArray->GetNumberOfCells();
+  int nlines = linesArray.IsNotNull() ? linesArray->GetNumberOfCells() : 0;
   if (nlines > 0)
     {
     vtkSmartPointer<vtkCellArray> lineCells = vtkSmartPointer<vtkCellArray>::New();
@@ -231,7 +231,7 @@ int vtkIGTLToMRMLPolyData::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRML
 
   // Polygons
   igtl::PolyDataCellArray::Pointer polygonsArray = polyDataMsg->GetPolygons();
-  int npolygons = polygonsArray->GetNumberOfCells();
+  int npolygons = polygonsArray.IsNotNull() ? polygonsArray->GetNumberOfCells() : 0;
   if (npolygons > 0)
     {
     vtkSmartPointer<vtkCellArray> polygonCells = vtkSmartPointer<vtkCellArray>::New();
@@ -256,7 +256,7 @@ int vtkIGTLToMRMLPolyData::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRML
 
   // Triangle Strips
   igtl::PolyDataCellArray::Pointer triangleStripsArray = polyDataMsg->GetTriangleStrips();
-  int ntstrips = triangleStripsArray->GetNumberOfCells();
+  int ntstrips = triangleStripsArray.IsNotNull() ? triangleStripsArray->GetNumberOfCells() : 0;
   if (ntstrips > 0)
     {
     vtkSmartPointer<vtkCellArray> tstripCells = vtkSmartPointer<vtkCellArray>::New();
@@ -433,7 +433,7 @@ int vtkIGTLToMRMLPolyData::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode
     vtkSmartPointer<vtkCellArray> polygonCells = poly->GetPolys();
     if (polygonCells.GetPointer() != NULL)
       {
-      igtl::PolyDataCellArray::Pointer polygonsArray;
+      igtl::PolyDataCellArray::Pointer polygonsArray = igtl::PolyDataCellArray::New();
       if (this->VTKToIGTLCellArray(polygonCells, polygonsArray) > 0)
         {
         this->OutPolyDataMessage->SetPolygons(polygonsArray);
@@ -475,7 +475,7 @@ int vtkIGTLToMRMLPolyData::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode
       for (int i = 0; i < nCellAttributes; i ++)
         {
         igtl::PolyDataAttribute::Pointer attribute = igtl::PolyDataAttribute::New();
-        if (this->VTKToIGTLAttribute(pdata, i, attribute) > 0)
+        if (this->VTKToIGTLAttribute(cdata, i, attribute) > 0)
           {
           this->OutPolyDataMessage->AddAttribute(attribute);
           }
@@ -612,7 +612,7 @@ int vtkIGTLToMRMLPolyData::VTKToIGTLAttribute(vtkDataSetAttributes* src, int i, 
     {
     dest->SetType(igtl::PolyDataAttribute::POINT_RGBA | attrTypeBit);
     }
-  dest->SetName(array->GetName());
+  dest->SetName(array->GetName() ? array->GetName() : "");
   int ntuples = array->GetNumberOfTuples();
   dest->SetSize(ntuples);
   

--- a/MRML/vtkIGTLToMRMLPolyData.cxx
+++ b/MRML/vtkIGTLToMRMLPolyData.cxx
@@ -380,10 +380,9 @@ int vtkIGTLToMRMLPolyData::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode
     
     //------------------------------------------------------------
     // Allocate Status Message Class
-    if (this->OutPolyDataMessage.IsNull())
-      {
-      this->OutPolyDataMessage = igtl::PolyDataMessage::New();
-      }
+    // Overwrite old message because we want to clear arrays from previous
+    // calls that will not be set anew.
+    this->OutPolyDataMessage = igtl::PolyDataMessage::New();
     
     // Set message name -- use the same name as the MRML node 
     this->OutPolyDataMessage->SetDeviceName(modelNode->GetName());


### PR DESCRIPTION
Fixes for several issues encountered while sending vtkPolyData and vtkImageData out from and into Slicer3D. See issues #54, #55 and #56 for details.

The pull request has been tested manually on the nightly Slicer build, MacOSX only. Another version of the code (in https://github.com/SINTEFMedtek/CustusX/tree/master/source/resource/OpenIGTLinkUtilities) has also been tested on Ubuntu14.04 and Windows 8.