### PR TITLE
BUG: Set hide from editors flag on OpenIGTLinkIF nodes

### DIFF
--- a/MRML/vtkMRMLIGTLTrackingDataBundleNode.cxx
+++ b/MRML/vtkMRMLIGTLTrackingDataBundleNode.cxx
@@ -42,6 +42,8 @@ vtkMRMLNodeNewMacro(vtkMRMLIGTLTrackingDataBundleNode);
 vtkMRMLIGTLTrackingDataBundleNode::vtkMRMLIGTLTrackingDataBundleNode()
 {
   this->TrackingDataList.clear();
+
+  this->HideFromEditors = 1;
 }
 
 //----------------------------------------------------------------------------

--- a/MRML/vtkMRMLIGTLTrackingDataQueryNode.cxx
+++ b/MRML/vtkMRMLIGTLTrackingDataQueryNode.cxx
@@ -46,6 +46,8 @@ vtkMRMLIGTLTrackingDataQueryNode::vtkMRMLIGTLTrackingDataQueryNode()
 
   this->TimeStamp = 0.0;
   this->TimeOut   = 0.0;
+
+  this->HideFromEditors = 1;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
After svn revision 22937[1], the default for the HideFromEditors
flag on the vtkMRMLNode superclass was set to 0 so that new nodes
are visible by default. Bug 2906[2] includes a comment with a python
script that instantiates all registered nodes with default values and
results in some OpenIGTLinkIF nodes showing in the Data module.
This change resets the hide from editors flag to 1 on tracking data
bundle nodes as they seemed to not be displayed in the GUI.

[1] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=22937
[2] http://www.na-mic.org/Bug/view.php?id=2906

Slicer Issue #2906