### PR TITLE
ENH: Removed TRANSFORM_NODE_MATRIX_COPY_REQUIRED ifdefs

### DIFF
--- a/MRML/vtkIGTLToMRMLLinearTransform.cxx
+++ b/MRML/vtkIGTLToMRMLLinearTransform.cxx
@@ -161,12 +161,7 @@ int vtkIGTLToMRMLLinearTransform::IGTLToMRML(igtl::MessageBase::Pointer buffer, 
   transform->Element[1][3] = py;
   transform->Element[2][3] = pz;
 
-#ifdef TRANSFORM_NODE_MATRIX_COPY_REQUIRED
   transformNode->SetMatrixTransformToParent(transform.GetPointer());
-#else
-  transformNode->SetAndObserveMatrixTransformToParent(transform.GetPointer());
-#endif
-
 
   //std::cerr << "IGTL matrix = " << std::endl;
   //transform->Print(cerr);
@@ -184,12 +179,8 @@ int vtkIGTLToMRMLLinearTransform::MRMLToIGTL(unsigned long event, vtkMRMLNode* m
     {
     vtkMRMLLinearTransformNode* transformNode =
       vtkMRMLLinearTransformNode::SafeDownCast(mrmlNode);
-#ifdef TRANSFORM_NODE_MATRIX_COPY_REQUIRED
     vtkNew<vtkMatrix4x4> matrix;
     transformNode->GetMatrixTransformToParent(matrix.GetPointer());
-#else
-    vtkMatrix4x4* matrix=transformNode->GetMatrixTransformToParent();
-#endif
 
     //igtl::TransformMessage::Pointer OutTransformMsg;
     if (this->OutTransformMsg.IsNull())

--- a/MRML/vtkIGTLToMRMLPosition.cxx
+++ b/MRML/vtkIGTLToMRMLPosition.cxx
@@ -134,11 +134,7 @@ int vtkIGTLToMRMLPosition::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRML
   transformToParent->Element[3][2] = 0.0;
   transformToParent->Element[3][3] = 1.0;
 
-#ifdef TRANSFORM_NODE_MATRIX_COPY_REQUIRED
   transformNode->SetMatrixTransformToParent(transformToParent.GetPointer());
-#else
-  transformNode->SetAndObserveMatrixTransformToParent(transformToParent.GetPointer());
-#endif
 
   return 1;
 }
@@ -150,12 +146,8 @@ int vtkIGTLToMRMLPosition::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode
     {
     vtkMRMLLinearTransformNode* transformNode =
       vtkMRMLLinearTransformNode::SafeDownCast(mrmlNode);
-#ifdef TRANSFORM_NODE_MATRIX_COPY_REQUIRED
     vtkNew<vtkMatrix4x4> matrix;
     transformNode->GetMatrixTransformToParent(matrix.GetPointer());
-#else
-    vtkMatrix4x4* matrix = transformNode->GetMatrixTransformToParent();
-#endif
 
     //igtl::PositionMessage::Pointer OutPositionMsg;
     if (this->OutPositionMsg.IsNull())

--- a/MRML/vtkMRMLIGTLTrackingDataBundleNode.cxx
+++ b/MRML/vtkMRMLIGTLTrackingDataBundleNode.cxx
@@ -168,11 +168,7 @@ void vtkMRMLIGTLTrackingDataBundleNode::UpdateTransformNode(const char* name, ig
     {
     vtkmat[i] = igtlmat[i];
     }
-#ifdef TRANSFORM_NODE_MATRIX_COPY_REQUIRED
   node->SetMatrixTransformToParent(mat.GetPointer());
-#else
-  node->SetAndObserveMatrixTransformToParent(mat.GetPointer());
-#endif
 
 }
 


### PR DESCRIPTION
TRANSFORM_NODE_MATRIX_COPY_REQUIRED was only needed temporarily (when stable and nightly Slicer versions used different transform node matrix get/set methods).