### PR TITLE
ENH: Adding UI and MRML property to enable toggling of error log output

### DIFF
--- a/GUI/qSlicerIGTLConnectorPropertyWidget.cxx
+++ b/GUI/qSlicerIGTLConnectorPropertyWidget.cxx
@@ -43,6 +43,8 @@ void qSlicerIGTLConnectorPropertyWidgetPrivate::init()
                    q, SLOT(startCurrentIGTLConnector(bool)));
   QObject::connect(this->PersistentStateCheckBox, SIGNAL(toggled(bool)),
                    q, SLOT(updateIGTLConnectorNode()));
+  QObject::connect(this->LogConnectionErrorCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorHostNameEdit, SIGNAL(editingFinished()),
                    q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorPortEdit, SIGNAL(editingFinished()),
@@ -174,6 +176,7 @@ void qSlicerIGTLConnectorPropertyWidget::onMRMLNodeModified()
     }
   d->ConnectorStateCheckBox->setChecked(!deactivated);
   d->PersistentStateCheckBox->setChecked(d->IGTLConnectorNode->GetPersistent() == vtkMRMLIGTLConnectorNode::PERSISTENT_ON);
+  d->LogConnectionErrorCheckBox->setChecked(d->IGTLConnectorNode->GetLogErrorIfServerConnectionFailed());
 }
 
 //------------------------------------------------------------------------------
@@ -205,6 +208,7 @@ void qSlicerIGTLConnectorPropertyWidget::updateIGTLConnectorNode()
   d->IGTLConnectorNode->SetPersistent(d->PersistentStateCheckBox->isChecked() ?
                                       vtkMRMLIGTLConnectorNode::PERSISTENT_ON :
                                       vtkMRMLIGTLConnectorNode::PERSISTENT_OFF);
+  d->IGTLConnectorNode->SetLogErrorIfServerConnectionFailed(d->LogConnectionErrorCheckBox->isChecked());
 
   d->IGTLConnectorNode->DisableModifiedEventOff();
   d->IGTLConnectorNode->InvokePendingModifiedEvent();

--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -71,6 +71,7 @@ vtkMRMLIGTLConnectorNode::vtkMRMLIGTLConnectorNode()
   this->Type   = TYPE_NOT_DEFINED;
   this->State  = STATE_OFF;
   this->Persistent = PERSISTENT_OFF;
+  this->LogErrorIfServerConnectionFailed = true;
 
   this->Thread = vtkMultiThreader::New();
   this->ServerStopFlag = false;
@@ -256,6 +257,12 @@ void vtkMRMLIGTLConnectorNode::ReadXMLAttributes(const char** atts)
       std::stringstream ss;
       ss << attValue;
       ss >> state;
+      }
+    if (!strcmp(attName, "logErrorIfServerConnectionFailed"))
+      {
+      std::stringstream ss;
+      ss << attValue;
+      ss >> LogErrorIfServerConnectionFailed;
       }
     }
 
@@ -739,7 +746,7 @@ int vtkMRMLIGTLConnectorNode::WaitForConnection()
     else if (this->Type == TYPE_CLIENT) // if this->Type == TYPE_CLIENT
       {
       //vtkErrorMacro("vtkMRMLIGTLConnectorNode: Connecting to server...");
-      int r = this->Socket->ConnectToServer(this->ServerHostname.c_str(), this->ServerPort);
+      int r = this->Socket->ConnectToServer(this->ServerHostname.c_str(), this->ServerPort, this->LogErrorIfServerConnectionFailed);
       if (r == 0) // if connected to server
         {
         return 1;

--- a/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/MRML/vtkMRMLIGTLConnectorNode.h
@@ -176,6 +176,8 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   vtkGetMacro( State, int );
   vtkSetMacro( RestrictDeviceName, int );
   vtkGetMacro( RestrictDeviceName, int );
+  vtkSetMacro( LogErrorIfServerConnectionFailed, bool);
+  vtkGetMacro( LogErrorIfServerConnectionFailed, bool);
 
   // Controls if active connection will be resumed when
   // scene is loaded (cf: PERSISTENT_ON/_OFF)
@@ -360,6 +362,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   int Type;
   int State;
   int Persistent;
+  bool LogErrorIfServerConnectionFailed;
 
   //----------------------------------------------------------------
   // Thread and Socket

--- a/Resources/UI/qSlicerIGTLConnectorPropertyWidget.ui
+++ b/Resources/UI/qSlicerIGTLConnectorPropertyWidget.ui
@@ -91,6 +91,16 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="LogConnectionErrorCheckBox">
+          <property name="text">
+           <string>Log Connection Errors</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item row="3" column="0">


### PR DESCRIPTION
In order to support the error log toggle, I've added a UI element in keeping with the current style and all the infrastructure elements to pass the UI value to the behavior.