### PR TITLE
Fix compilation with VTK 7.1

### DIFF
--- a/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/MRML/vtkMRMLIGTLConnectorNode.h
@@ -145,6 +145,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   // method to propagate events generated in mrml
   virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
 
+#ifndef __VTK_WRAP__
   //BTX
   virtual void OnNodeReferenceAdded(vtkMRMLNodeReference *reference);
 
@@ -152,6 +153,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
 
   virtual void OnNodeReferenceModified(vtkMRMLNodeReference *reference);
   //ETX
+#endif // __VTK_WRAP__
 
  protected:
   //----------------------------------------------------------------


### PR DESCRIPTION
When Slicer is built with the current VTK master (upcoming VTK 7.1), compilation
fails with errors similar to:

    C:\path\to\Slicer-build\Modules\Remote\OpenIGTLinkIF\MRML\vtkMRMLIGTLConnectorNodePython.cxx(260): error C2065: 'vtkMRMLNodeReference' : undeclared identifier
    C:\path\to\Slicer-build\Modules\Remote\OpenIGTLinkIF\MRML\vtkMRMLIGTLConnectorNodePython.cxx(260): error C2065: 'temp0' : undeclared identifier

This happens because VTK wrapping no longer recognizes BTX/ETX markers as
indicators to skip wrapping of a block of code; see
https://github.com/Kitware/VTK/commit/55878a2. In many cases the updated
wrapping tools can handle code that was previously had to be skipped, but in
this case wrapping still fails.

In VTK 7.1 blocks of code can be skipped for wrapping by checking whether
`__VTK_WRAP__` is defined. This commit adds such a check to the functions in
vtkMRMLIGTLConnectorNode that are surrounded by BTX/ETX.