### PR TITLE
EHN: UnpackIGTLMessage needs to be performed if the IGTLToMRML is cal…

### DIFF
--- a/MRML/vtkIGTLToMRMLImage.cxx
+++ b/MRML/vtkIGTLToMRMLImage.cxx
@@ -295,7 +295,10 @@ int vtkIGTLToMRMLImage::IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNod
   int   numComponents;    // number of scalar components
   int   endian;
   igtl::Matrix4x4 matrix; // Image origin and orientation matrix
-
+  if(this->InImageMessage.IsNull())
+  {
+    this->UnpackIGTLMessage(buffer);
+  }
   scalarType = IGTLToVTKScalarType( this->InImageMessage->GetScalarType() );
   endian = this->InImageMessage->GetEndian();
   this->InImageMessage->GetDimensions(size);

--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -1155,7 +1155,6 @@ void vtkMRMLIGTLConnectorNode::ImportDataFromCircularBuffer()
     // to avoid accidental modification of the query queue as a result of response processing.
     std::vector< vtkMRMLIGTLQueryNode* > repliedQueryNodes;
     this->QueryQueueMutex->Lock();
-    double currentTime = vtkTimerLog::GetUniversalTime();
     if (this->QueryWaitingQueue.size() > 0 && updatedNode != NULL)
       {
       for (std::list< vtkWeakPointer<vtkMRMLIGTLQueryNode> >::iterator iter = this->QueryWaitingQueue.begin();


### PR DESCRIPTION
…led from outside projects. otherwise, the InImageMessage is not initialized and causes an invalid memory access bug,