### PR TITLE
BUG: Fixed crash when trying to add outgoing nodes

### DIFF
--- a/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -1583,18 +1583,27 @@ vtkMRMLNode* vtkMRMLIGTLConnectorNode::GetIncomingMRMLNode(unsigned int i)
 //---------------------------------------------------------------------------
 vtkIGTLToMRMLBase* vtkMRMLIGTLConnectorNode::GetConverterByMRMLTag(const char* tag)
 {
+  if (tag == NULL)
+    {
+    vtkErrorMacro("vtkMRMLIGTLConnectorNode::GetConverterByMRMLTag failed: invalid tag");
+    return NULL;
+    }
 
   MessageConverterListType::iterator iter;
   for (iter = this->MessageConverterList.begin();
        iter != this->MessageConverterList.end();
        iter ++)
     {
-    if(*iter)
+    if ((*iter) == NULL)
       {
-        for(int i = 0; (*iter)->GetAllMRMLNames().size(); i++)
+      continue;
+      }
+    std::vector<std::string> supportedMRMLNodeNames = (*iter)->GetAllMRMLNames();
+    for (int i = 0; i<supportedMRMLNodeNames.size(); i++)
+      {
+      if (supportedMRMLNodeNames[i].compare(tag) == 0)
         {
-          if ( strcmp((*iter)->GetAllMRMLNames()[i].c_str(), tag) == 0)
-            return *iter;
+        return *iter;
         }
       }
     }


### PR DESCRIPTION
When I tried to add model node as an output node to push through OpenIGTLink, it always caused a Slicer crash.

The problem was introduced by a recent code cleanup ("i<" was accidentally removed from a for loop condition therefore the for loop did not exit).