### PR TITLE
COMP: vtkIGTLToMRMLTrajectory: Fix deprecated declaration warning

### DIFF
--- a/MRML/vtkIGTLToMRMLTrajectory.cxx
+++ b/MRML/vtkIGTLToMRMLTrajectory.cxx
@@ -171,9 +171,7 @@ int vtkIGTLToMRMLTrajectory::MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNo
     *size = this->OutTrajectoryMsg->GetPackSize();
     *igtlMsg = (void*)this->OutTrajectoryMsg->GetPackPointer();
 
-    // BUG: The parameter is not necessary for this method
-    igtl::TrajectoryElement::Pointer dummy;
-    this->OutTrajectoryMsg->ClearTrajectoryElement(dummy);
+    this->OutTrajectoryMsg->ClearAllTrajectoryElements();
 
     return 1;
     }


### PR DESCRIPTION
```
/path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLTrajectory.cxx: In member function ‘virtual int vtkIGTLToMRMLTrajectory::MRMLToIGTL(long unsigned int, vtkMRMLNode*, int*, void**)’:
/path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLTrajectory.cxx:176:57: warning: ‘void igtl::TrajectoryMessage::ClearTrajectoryElement(igtl::TrajectoryElement::Pointer&)’ is deprecated [-Wdeprecated-declarations]
     this->OutTrajectoryMsg->ClearTrajectoryElement(dummy);
                                                         ^
In file included from /path/to/Slicer-build/OpenIGTLink/Source/igtlMessageBase.h:18:0,
                 from /path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLBase.h:22,
                 from /path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLTrajectory.h:16,
                 from /path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLTrajectory.cxx:13:
/path/to/Slicer-build/OpenIGTLink/Source/igtlTrajectoryMessage.h:190:3: note: declared here
   igtlLegacyMacro(
   ^
```