### PR TITLE
COMP: Fix "inconsistent-missing-override" warnings

### DIFF
--- a/Logic/vtkSlicerOpenIGTLinkIFLogic.h
+++ b/Logic/vtkSlicerOpenIGTLinkIFLogic.h
@@ -80,26 +80,26 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_LOGIC_EXPORT vtkSlicerOpenIGTLinkIFLogic :
 
   static vtkSlicerOpenIGTLinkIFLogic *New();
   vtkTypeMacro(vtkSlicerOpenIGTLinkIFLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream&, vtkIndent);
+  void PrintSelf(ostream&, vtkIndent) VTK_OVERRIDE;
 
   /// The selected transform node is observed for TransformModified events and the transform
   /// data is copied to the slice nodes depending on the current mode
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) VTK_OVERRIDE;
 
-  virtual void RegisterNodes();
+  virtual void RegisterNodes() VTK_OVERRIDE;
 
   //----------------------------------------------------------------
   // Events
   //----------------------------------------------------------------
 
-  virtual void OnMRMLSceneEndImport();
+  virtual void OnMRMLSceneEndImport() VTK_OVERRIDE;
 
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* /*node*/);
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* /*node*/) VTK_OVERRIDE;
 
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* /*node*/);
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* /*node*/) VTK_OVERRIDE;
 
-  virtual void OnMRMLNodeModified(vtkMRMLNode* /*node*/){}
+  virtual void OnMRMLNodeModified(vtkMRMLNode* /*node*/) VTK_OVERRIDE{}
 
   //----------------------------------------------------------------
   // Connector and converter Management
@@ -126,7 +126,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_LOGIC_EXPORT vtkSlicerOpenIGTLinkIFLogic :
   // MRML Management
   //----------------------------------------------------------------
   
-  virtual void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void * callData);
+  virtual void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void * callData) VTK_OVERRIDE;
   //virtual void ProcessLogicEvents(vtkObject * caller, unsigned long event, void * callData);
 
   void ProcCommand(const char* nodeName, int size, unsigned char* data);

--- a/MRML/vtkIGTLCircularBuffer.h
+++ b/MRML/vtkIGTLCircularBuffer.h
@@ -38,7 +38,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLCircularBuffer : public
   static vtkIGTLCircularBuffer *New();
   vtkTypeMacro(vtkIGTLCircularBuffer,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   int GetNumberOfBuffer() { return IGTLCB_CIRC_BUFFER_SIZE; }
 

--- a/MRML/vtkIGTLToMRMLBase.h
+++ b/MRML/vtkIGTLToMRMLBase.h
@@ -55,7 +55,7 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLBase : public vtk
   static vtkIGTLToMRMLBase *New();
   vtkTypeMacro(vtkIGTLToMRMLBase,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   virtual int          GetConverterType() { return TYPE_NORMAL; };
 

--- a/MRML/vtkIGTLToMRMLImage.h
+++ b/MRML/vtkIGTLToMRMLImage.h
@@ -37,10 +37,10 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImage : public vt
   static vtkIGTLToMRMLImage *New();
   vtkTypeMacro(vtkIGTLToMRMLImage,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "IMAGE"; };
-  virtual const char*  GetMRMLName()
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "IMAGE"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE
   {
     if(this->InImageMessage.IsNotNull())
     {
@@ -51,13 +51,13 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImage : public vt
     }
     return "Volume";
   };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNodeWithMessage(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer incomingImageMessage);
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNodeWithMessage(vtkMRMLScene* scene, const char* name, igtl::MessageBase::Pointer incomingImageMessage) VTK_OVERRIDE;
 
-  virtual int          UnpackIGTLMessage(igtl::MessageBase::Pointer buffer);
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
-  virtual std::vector<std::string>  GetAllMRMLNames()
+  virtual int          UnpackIGTLMessage(igtl::MessageBase::Pointer buffer) VTK_OVERRIDE;
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
+  virtual std::vector<std::string>  GetAllMRMLNames() VTK_OVERRIDE
   {
     this->MRMLNames.clear();
     this->MRMLNames.push_back("VectorVolume");

--- a/MRML/vtkIGTLToMRMLImageMetaList.h
+++ b/MRML/vtkIGTLToMRMLImageMetaList.h
@@ -34,16 +34,16 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLImageMetaList : p
   static vtkIGTLToMRMLImageMetaList *New();
   vtkTypeMacro(vtkIGTLToMRMLImageMetaList,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "IMGMETA"; };
-  virtual const char*  GetMRMLName() { return "ImageMetaList"; };
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "IMGMETA"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "ImageMetaList"; };
 
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLLabelMetaList.h
+++ b/MRML/vtkIGTLToMRMLLabelMetaList.h
@@ -31,16 +31,16 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLLabelMetaList : p
   static vtkIGTLToMRMLLabelMetaList *New();
   vtkTypeMacro(vtkIGTLToMRMLLabelMetaList,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "LBMETA"; };
-  virtual const char*  GetMRMLName() { return "LabelMetaList"; };
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "LBMETA"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "LabelMetaList"; };
 
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLLinearTransform.h
+++ b/MRML/vtkIGTLToMRMLLinearTransform.h
@@ -38,18 +38,18 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLLinearTransform :
   static vtkIGTLToMRMLLinearTransform *New();
   vtkTypeMacro(vtkIGTLToMRMLLinearTransform,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "TRANSFORM"; };
-  virtual const char*  GetMRMLName() { return "LinearTransform"; };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "TRANSFORM"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "LinearTransform"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
-  virtual int IsVisible() { return 1; };
-  virtual void SetVisibility(int sw, vtkMRMLScene * scene, vtkMRMLNode * node);
+  virtual int IsVisible() VTK_OVERRIDE { return 1; };
+  virtual void SetVisibility(int sw, vtkMRMLScene * scene, vtkMRMLNode * node) VTK_OVERRIDE;
 
  protected:
   vtkIGTLToMRMLLinearTransform();

--- a/MRML/vtkIGTLToMRMLPoints.h
+++ b/MRML/vtkIGTLToMRMLPoints.h
@@ -29,18 +29,18 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPoints : public v
   static vtkIGTLToMRMLPoints *New();
   vtkTypeMacro(vtkIGTLToMRMLPoints,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "POINT"; };
-  virtual const char*  GetMRMLName() { return "MarkupsFiducial"; };
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "POINT"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "MarkupsFiducial"; };
 
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
   //BTX
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
   //ETX
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLPolyData.h
+++ b/MRML/vtkIGTLToMRMLPolyData.h
@@ -37,16 +37,16 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPolyData : public
   static vtkIGTLToMRMLPolyData *New();
   vtkTypeMacro(vtkIGTLToMRMLPolyData,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "POLYDATA"; };
-  virtual const char*  GetMRMLName() { return "Model"; };
-  virtual vtkIntArray* GetNodeEvents();
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "POLYDATA"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "Model"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
   virtual vtkMRMLNode* CreateNewNodeWithMessage(vtkMRMLScene* scene, const char* name,
-                                                igtl::MessageBase::Pointer incomingPolyDataMessage);
+                                                igtl::MessageBase::Pointer incomingPolyDataMessage) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLPosition.h
+++ b/MRML/vtkIGTLToMRMLPosition.h
@@ -32,15 +32,15 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLPosition : public
   static vtkIGTLToMRMLPosition *New();
   vtkTypeMacro(vtkIGTLToMRMLPosition,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "POSITION"; };
-  virtual const char*  GetMRMLName() { return "LinearTransform"; };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "POSITION"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "LinearTransform"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLSensor.h
+++ b/MRML/vtkIGTLToMRMLSensor.h
@@ -32,15 +32,15 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLSensor : public v
   static vtkIGTLToMRMLSensor *New();
   vtkTypeMacro(vtkIGTLToMRMLSensor,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "SENSOR"; };
-  virtual const char*  GetMRMLName() { return "IGTLSensor"; };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "SENSOR"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "IGTLSensor"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLStatus.h
+++ b/MRML/vtkIGTLToMRMLStatus.h
@@ -32,15 +32,15 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLStatus : public v
   static vtkIGTLToMRMLStatus *New();
   vtkTypeMacro(vtkIGTLToMRMLStatus,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "STATUS"; };
-  virtual const char*  GetMRMLName() { return "IGTLStatus"; };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "STATUS"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "IGTLStatus"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLString.h
+++ b/MRML/vtkIGTLToMRMLString.h
@@ -27,22 +27,22 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLString : public v
   static vtkIGTLToMRMLString *New();
   vtkTypeMacro(vtkIGTLToMRMLString,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual int          GetConverterType() { return TYPE_NORMAL; };
-  virtual const char*  GetIGTLName() { return "STRING"; };
-  virtual const char*  GetMRMLName() { return "Text"; };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual int          GetConverterType() VTK_OVERRIDE { return TYPE_NORMAL; };
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "STRING"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "Text"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
   // for TYPE_MULTI_IGTL_NAMES
   int                  GetNumberOfIGTLNames()   { return this->IGTLNames.size(); };
   const char*          GetIGTLName(int index)   { return this->IGTLNames[index].c_str(); };
 
   //BTX
-  virtual int          IGTLToMRML( igtl::MessageBase::Pointer buffer, vtkMRMLNode* node );
+  virtual int          IGTLToMRML( igtl::MessageBase::Pointer buffer, vtkMRMLNode* node ) VTK_OVERRIDE;
   //ETX
-  virtual int          MRMLToIGTL( unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg );
+  virtual int          MRMLToIGTL( unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg ) VTK_OVERRIDE;
 
  
  protected:

--- a/MRML/vtkIGTLToMRMLTrackingData.h
+++ b/MRML/vtkIGTLToMRMLTrackingData.h
@@ -37,16 +37,16 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLTrackingData : pu
   static vtkIGTLToMRMLTrackingData *New();
   vtkTypeMacro(vtkIGTLToMRMLTrackingData,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "TDATA"; };
-  virtual const char*  GetMRMLName() { return "IGTLTrackingDataSplitter"; };
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "TDATA"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "IGTLTrackingDataSplitter"; };
 
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkIGTLToMRMLTrajectory.h
+++ b/MRML/vtkIGTLToMRMLTrajectory.h
@@ -38,15 +38,15 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkIGTLToMRMLTrajectory : publ
   static vtkIGTLToMRMLTrajectory *New();
   vtkTypeMacro(vtkIGTLToMRMLTrajectory,vtkObject);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual const char*  GetIGTLName() { return "TRAJ"; };
-  virtual const char*  GetMRMLName() { return "AnnotationHierarchyNode"; };
-  virtual vtkIntArray* GetNodeEvents();
-  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name);
+  virtual const char*  GetIGTLName() VTK_OVERRIDE { return "TRAJ"; };
+  virtual const char*  GetMRMLName() VTK_OVERRIDE { return "AnnotationHierarchyNode"; };
+  virtual vtkIntArray* GetNodeEvents() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNewNode(vtkMRMLScene* scene, const char* name) VTK_OVERRIDE;
 
-  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node);
-  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg);
+  virtual int          IGTLToMRML(igtl::MessageBase::Pointer buffer, vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual int          MRMLToIGTL(unsigned long event, vtkMRMLNode* mrmlNode, int* size, void** igtlMsg) VTK_OVERRIDE;
 
 
  protected:

--- a/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/MRML/vtkMRMLIGTLConnectorNode.h
@@ -121,37 +121,37 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   static vtkMRMLIGTLConnectorNode *New();
   vtkTypeMacro(vtkMRMLIGTLConnectorNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   // Description:
   // Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName()
+  virtual const char* GetNodeTagName() VTK_OVERRIDE
     {return "IGTLConnector";};
 
   // method to propagate events generated in mrml
-  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData ) VTK_OVERRIDE;
 
 #ifndef __VTK_WRAP__
   //BTX
-  virtual void OnNodeReferenceAdded(vtkMRMLNodeReference *reference);
+  virtual void OnNodeReferenceAdded(vtkMRMLNodeReference *reference) VTK_OVERRIDE;
 
-  virtual void OnNodeReferenceRemoved(vtkMRMLNodeReference *reference);
+  virtual void OnNodeReferenceRemoved(vtkMRMLNodeReference *reference) VTK_OVERRIDE;
 
-  virtual void OnNodeReferenceModified(vtkMRMLNodeReference *reference);
+  virtual void OnNodeReferenceModified(vtkMRMLNodeReference *reference) VTK_OVERRIDE;
   //ETX
 #endif // __VTK_WRAP__
 

--- a/MRML/vtkMRMLIGTLQueryNode.h
+++ b/MRML/vtkMRMLIGTLQueryNode.h
@@ -101,25 +101,25 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLQueryNode : public 
   static vtkMRMLIGTLQueryNode *New();
   vtkTypeMacro(vtkMRMLIGTLQueryNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   // Description:
   // Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName()
+  virtual const char* GetNodeTagName() VTK_OVERRIDE
   { return "IGTLQuery"; };
 
   // Description:

--- a/MRML/vtkMRMLIGTLSensorNode.h
+++ b/MRML/vtkMRMLIGTLSensorNode.h
@@ -24,21 +24,21 @@ public:
 
   vtkTypeMacro(vtkMRMLIGTLSensorNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   /// 
   /// Read node attributes from XML file
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   /// 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   /// 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "IGTLSensor";};
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "IGTLSensor";};
 
   /// Set length of data array
   int SetArrayLength(vtkTypeUInt8 length);

--- a/MRML/vtkMRMLIGTLStatusNode.h
+++ b/MRML/vtkMRMLIGTLStatusNode.h
@@ -23,21 +23,21 @@ public:
 
   vtkTypeMacro(vtkMRMLIGTLStatusNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   /// 
   /// Read node attributes from XML file
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   /// 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   /// 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "IGTLStatus";};
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "IGTLStatus";};
 
   /// Set a status code. Return 0 if the code is invalid.
   int SetCode(vtkTypeUInt16 code);

--- a/MRML/vtkMRMLIGTLTrackingDataBundleNode.h
+++ b/MRML/vtkMRMLIGTLTrackingDataBundleNode.h
@@ -72,29 +72,29 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLTrackingDataBundleN
   static vtkMRMLIGTLTrackingDataBundleNode *New();
   vtkTypeMacro(vtkMRMLIGTLTrackingDataBundleNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   // Description:
   // Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName()
+  virtual const char* GetNodeTagName() VTK_OVERRIDE
   { return "IGTLTrackingDataSplitter"; };
 
   // method to propagate events generated in mrml
-  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData ) VTK_OVERRIDE;
 
   // Description:
   // Update Transform nodes. If new data is specified, create a new Transform node.

--- a/MRML/vtkMRMLIGTLTrackingDataQueryNode.h
+++ b/MRML/vtkMRMLIGTLTrackingDataQueryNode.h
@@ -79,29 +79,29 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLTrackingDataQueryNo
   static vtkMRMLIGTLTrackingDataQueryNode *New();
   vtkTypeMacro(vtkMRMLIGTLTrackingDataQueryNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   // Description:
   // Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName()
+  virtual const char* GetNodeTagName() VTK_OVERRIDE
   { return "IGTLQuery"; };
 
   // method to propagate events generated in mrml
-  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData ) VTK_OVERRIDE;
 
   // Description:
   // Get OpenIGTLink device name. If the query node is for IMAGE, "IMAGE" is returned.

--- a/MRML/vtkMRMLImageMetaListNode.h
+++ b/MRML/vtkMRMLImageMetaListNode.h
@@ -66,29 +66,29 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLImageMetaListNode : pub
   static vtkMRMLImageMetaListNode *New();
   vtkTypeMacro(vtkMRMLImageMetaListNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   // Description:
   // Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName()
+  virtual const char* GetNodeTagName() VTK_OVERRIDE
   {return "ImageMetaList";};
 
   // method to propagate events generated in mrml
-  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData ) VTK_OVERRIDE;
 
   // Description:
   // Get number of image meta element stored in this class instance

--- a/MRML/vtkMRMLLabelMetaListNode.h
+++ b/MRML/vtkMRMLLabelMetaListNode.h
@@ -62,29 +62,29 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLLabelMetaListNode : pub
   static vtkMRMLLabelMetaListNode *New();
   vtkTypeMacro(vtkMRMLLabelMetaListNode,vtkMRMLNode);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   // Description:
   // Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName()
+  virtual const char* GetNodeTagName() VTK_OVERRIDE
   {return "LabelMetaList";};
 
   // method to propagate events generated in mrml
-  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData ) VTK_OVERRIDE;
 
   // Description:
   // Get number of label meta element stored in this class instance

--- a/MRML/vtkMRMLTextNode.h
+++ b/MRML/vtkMRMLTextNode.h
@@ -24,25 +24,25 @@ public:
 
   static vtkMRMLTextNode *New();
   vtkTypeMacro(vtkMRMLTextNode,vtkMRMLNode);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
   
   ///
   /// Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   ///
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   ///
   /// Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   ///
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "Text";};
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "Text";};
 
   ///
   /// Set text encoding


### PR DESCRIPTION
This commit adds the VTK_OVERRIDE macros to fix warnings like the one
reported below occurring when building OpenIGTLink against VTK 8:

In file included from /path/to/Slicer-build/Slicer-build/Modules/Remote/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPointsPython.cxx:12:
In file included from /path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPoints.h:19:
/path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLBase.h:58:8: warning: 'PrintSelf' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void PrintSelf(ostream& os, vtkIndent indent);
       ^
/path/to/Slicer-build/VTKv8/Common/Core/vtkObject.h:115:8: note: overridden virtual function is here
  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
       ^
