### PR TITLE
ENH: Add support for Qt5

### DIFF
--- a/qSlicerOpenIGTLinkIFModule.cxx
+++ b/qSlicerOpenIGTLinkIFModule.cxx
@@ -13,7 +13,6 @@
 ==========================================================================*/
 
 // Qt includes
-#include <QtPlugin>
 #include <QTimer>
 
 #include "qSlicerCoreApplication.h"
@@ -29,7 +28,11 @@
 
 
 //-----------------------------------------------------------------------------
+#include <QtGlobal>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+#include <QtPlugin>
 Q_EXPORT_PLUGIN2(qSlicerOpenIGTLinkIFModule, qSlicerOpenIGTLinkIFModule);
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_OpenIGTLinkIF

--- a/qSlicerOpenIGTLinkIFModule.h
+++ b/qSlicerOpenIGTLinkIFModule.h
@@ -15,6 +15,9 @@ class Q_SLICER_QTMODULES_OPENIGTLINKIF_EXPORT qSlicerOpenIGTLinkIFModule :
 {
   Q_OBJECT;
   QVTK_OBJECT;
+#ifdef Slicer_HAVE_QT5
+  Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
+#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
Use Slicer_HAVE_QT5 to workaround limitation of "moc" compiler
preventing it from expanding macro like "QT_VERSION_CHECK.