### PR TITLE
Update build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,13 @@ set(MODULE_TITLE "OpenIGTLink I/F")
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
 #-----------------------------------------------------------------------------
-find_package(Slicer REQUIRED)
-include(${Slicer_USE_FILE})
+if(Slicer_SOURCE_DIR)
+  find_package(OpenIGTLink REQUIRED)
+  include(${OpenIGTLink_USE_FILE})
+else()
+  find_package(Slicer REQUIRED)
+  include(${Slicer_USE_FILE})
+endif()
 
 # --------------------------------------------------------------------------
 # Check if version 2 protocol is available
@@ -93,7 +98,6 @@ slicerMacroBuildQtModule(
   TARGET_LIBRARIES ${MODULE_TARGET_LIBRARIES}
   RESOURCES ${MODULE_RESOURCES}
   )
-
 
 if(BUILD_TESTING)
   #add_subdirectory(Testing)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
-
-if(POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW) # CMake 3.0.0
-endif()
+cmake_minimum_required(VERSION 3.5)
 
 set(MODULE_NAME "OpenIGTLinkIF")
 set(MODULE_TITLE "OpenIGTLink I/F")


### PR DESCRIPTION
commit `COMP: Improve support for building as a "Slicer Remote module" ` allows to remove this hack:

https://github.com/Slicer/Slicer/blob/a5c461ff2acdc6695267a9c3859627fb9d4d2932/Modules/Remote/CMakeLists.txt#L9-L15